### PR TITLE
Error in DEFAULT_DATA_PATH

### DIFF
--- a/neuspell/commons.py
+++ b/neuspell/commons.py
@@ -25,7 +25,7 @@ def custom_tokenizer(inp: str):
 spacy_tokenizer = custom_tokenizer
 
 """ constants """
-DEFAULT_DATA_PATH = "/neuspell/data/"
+DEFAULT_DATA_PATH = "/neuspell/data"
 assert os.path.isabs(DEFAULT_DATA_PATH)
 if not os.path.isdir(DEFAULT_DATA_PATH):
     print("******")


### PR DESCRIPTION
Since `DEFAULT_DATA_PATH ` is `/neuspell/data/`, this line leads to an error due to "//" in other corrector py files --> `self.ckpt_path = f"{DEFAULT_DATA_PATH}/checkpoints/elmoscrnn-probwordnoise"`

Sets the default path to `/neuspell/data`