### PR TITLE
Removed position embeddings for old models

### DIFF
--- a/neuspell/seq_modeling/subwordbert.py
+++ b/neuspell/seq_modeling/subwordbert.py
@@ -33,6 +33,10 @@ def load_pretrained(model, checkpoint_path, optimizer=None, device='cuda'):
     except FileNotFoundError:
         download_pretrained_model(checkpoint_path)
         checkpoint_data = torch.load(os.path.join(checkpoint_path, "pytorch_model.bin"), map_location=map_location)
+    
+    # From transformers v4.31.0, position_ids are part of state dict for bert_model
+    if "bert_model.embeddings.position_ids" in checkpoint_data:
+        del checkpoint_data["bert_model.embeddings.position_ids"]
 
     model.load_state_dict(checkpoint_data)
 


### PR DESCRIPTION
From transformers v4.31.0, position_ids are part of state dict for bert_model. See similar change made [here](https://github.com/NVIDIA/NeMo/pull/7068/commits/19a4e3583cffec86cd86232a76560d0cbea781ae) to NeMo.